### PR TITLE
Добавить шаблонный блок про достижения

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Hero from '@/components/sections/Hero'
 import About from '@/components/sections/About'
+import Achievements from '@/components/sections/Achievements'
 import WhatIsNutriciology from '@/components/sections/WhatIsNutriciology'
 import HowICanHelp from '@/components/sections/HowICanHelp'
 import Stats from '@/components/sections/Stats'
@@ -10,9 +11,7 @@ import Testimonials from '@/components/sections/Testimonials'
 import FAQ from '@/components/sections/FAQ'
 import CTA from '@/components/sections/CTA'
 import Contact from '@/components/sections/Contact'
-import StructuredData from '@/components/seo/StructuredData'
 import Breadcrumbs from '@/components/seo/Breadcrumbs'
-import { getBreadcrumbListStructuredData } from '@/lib/utils/seo'
 import type { Metadata } from 'next'
 import { META_DESCRIPTION_SHORT } from '@/lib/constants/seo'
 
@@ -59,6 +58,7 @@ export default function HomePage() {
       <Breadcrumbs items={breadcrumbItems} />
       <Hero />
       <About />
+      <Achievements />
       <WhatIsNutriciology />
       <HowICanHelp />
       <Stats />

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -7,6 +7,7 @@ import { socialLinks } from '@/lib/constants/social'
 
 const footerLinks = [
   { href: '#about', label: 'О специалисте' },
+  { href: '#achievements', label: 'Достижения' },
   { href: '#nutriciology', label: 'О нутрициологии' },
   { href: '#services', label: 'Услуги' },
   { href: '#testimonials', label: 'Отзывы' },
@@ -16,7 +17,10 @@ const footerLinks = [
 
 export default function Footer() {
   return (
-    <footer className="bg-beige-800 text-beige-50 py-10 xs:py-12 sm:py-14 md:py-16 w-full max-w-full overflow-x-hidden" role="contentinfo">
+    <footer
+      className="bg-beige-800 text-beige-50 py-10 xs:py-12 sm:py-14 md:py-16 w-full max-w-full overflow-x-hidden"
+      role="contentinfo"
+    >
       <div className="container mx-auto w-full max-w-full">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 xs:gap-10 sm:gap-12 mb-8 xs:mb-10 sm:mb-12">
           {/* О нас */}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,6 +8,7 @@ import { Menu, X } from 'lucide-react'
 
 const navItems = [
   { href: '#about', label: 'О специалисте' },
+  { href: '#achievements', label: 'Достижения' },
   { href: '#nutriciology', label: 'О нутрициологии' },
   { href: '#services', label: 'Услуги' },
   { href: '#testimonials', label: 'Отзывы' },

--- a/src/components/sections/Achievements.tsx
+++ b/src/components/sections/Achievements.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import AnimatedSection from '@/components/ui/AnimatedSection'
+import { achievementsContent } from '@/lib/content/achievements'
+import { Award, FileText, TrendingUp } from 'lucide-react'
+
+const iconMap = {
+  certificate: Award,
+  case: FileText,
+  result: TrendingUp,
+} as const
+
+export default function Achievements() {
+  return (
+    <AnimatedSection
+      id="achievements"
+      className="py-12 xs:py-16 sm:py-20 md:py-24 bg-beige-50 w-full max-w-full overflow-x-hidden"
+    >
+      <div className="container mx-auto w-full max-w-full overflow-x-hidden">
+        <div className="max-w-7xl mx-auto">
+          <motion.div
+            className="text-center mb-8 xs:mb-12 sm:mb-16"
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            <p className="text-xs xs:text-sm font-semibold tracking-widest text-beige-600 uppercase">
+              {achievementsContent.subtitle}
+            </p>
+            <h2 className="text-3xl xs:text-4xl sm:text-5xl md:text-6xl font-bold text-beige-800 mt-3 mb-3 xs:mb-4">
+              {achievementsContent.title}
+            </h2>
+            <p className="text-base xs:text-lg sm:text-xl text-beige-700 max-w-4xl mx-auto">
+              {achievementsContent.description}
+            </p>
+            <div className="w-24 h-1 bg-beige-500 mx-auto rounded-full mt-6" />
+          </motion.div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 xs:gap-6 sm:gap-8">
+            {achievementsContent.cards.map((card, index) => {
+              const Icon = iconMap[card.icon]
+
+              return (
+                <motion.div
+                  key={card.id}
+                  className="bg-white rounded-2xl xs:rounded-3xl shadow-lg border border-beige-200 overflow-hidden"
+                  initial={{ opacity: 0, y: 30 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.4, delay: index * 0.08 }}
+                  whileHover={{ y: -6, scale: 1.01 }}
+                >
+                  <div className="p-5 xs:p-6 sm:p-8">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex items-center gap-3 xs:gap-4">
+                        <div className="bg-beige-100 rounded-2xl p-3 xs:p-4 border border-beige-200">
+                          <Icon className="w-6 h-6 xs:w-7 xs:h-7 text-beige-700" />
+                        </div>
+                        <div>
+                          <h3 className="text-lg xs:text-xl sm:text-2xl font-bold text-beige-800">
+                            {card.title}
+                          </h3>
+                          <p className="text-xs xs:text-sm text-beige-600 mt-1">{card.period}</p>
+                        </div>
+                      </div>
+
+                      <span className="text-xs font-semibold px-3 py-1 rounded-full bg-beige-100 text-beige-700 border border-beige-200">
+                        Шаблон
+                      </span>
+                    </div>
+
+                    <p className="text-sm xs:text-base text-beige-700 mt-4 leading-relaxed">
+                      {card.summary}
+                    </p>
+
+                    <ul className="mt-4 space-y-2">
+                      {card.bullets.map((bullet) => (
+                        <li key={bullet} className="flex gap-3 text-sm xs:text-base text-beige-700">
+                          <span className="mt-2 w-2 h-2 rounded-full bg-beige-500 flex-shrink-0" />
+                          <span>{bullet}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </motion.div>
+              )
+            })}
+          </div>
+
+          <motion.div
+            className="mt-8 xs:mt-10 sm:mt-12 max-w-5xl mx-auto"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+          >
+            <div className="bg-white/70 backdrop-blur-sm border border-beige-200 rounded-2xl xs:rounded-3xl p-5 xs:p-6 sm:p-8 text-center">
+              <p className="text-sm xs:text-base text-beige-700">{achievementsContent.note}</p>
+            </div>
+          </motion.div>
+        </div>
+      </div>
+    </AnimatedSection>
+  )
+}

--- a/src/components/seo/Breadcrumbs.tsx
+++ b/src/components/seo/Breadcrumbs.tsx
@@ -18,8 +18,9 @@ interface BreadcrumbsProps {
 }
 
 export default function Breadcrumbs({ items, showVisual = false }: BreadcrumbsProps) {
-  const pathname = usePathname()
-  
+  // Подписка на смену маршрута (на некоторых страницах компонент используется повторно).
+  usePathname()
+
   // Для одностраничного сайта создаем виртуальные breadcrumbs
   const defaultItems: BreadcrumbItem[] = [
     { name: 'Главная', url: siteConfig.url },
@@ -31,6 +32,7 @@ export default function Breadcrumbs({ items, showVisual = false }: BreadcrumbsPr
     if (hash) {
       const sectionNames: Record<string, string> = {
         '#about': 'О специалисте',
+        '#achievements': 'Достижения',
         '#nutriciology': 'О нутрициологии',
         '#services': 'Услуги',
         '#testimonials': 'Отзывы',

--- a/src/lib/content/achievements.ts
+++ b/src/lib/content/achievements.ts
@@ -1,0 +1,61 @@
+export interface AchievementTemplateCard {
+  id: string
+  icon: 'certificate' | 'case' | 'result'
+  title: string
+  period: string
+  summary: string
+  bullets: readonly string[]
+}
+
+export const achievementsContent: {
+  readonly title: string
+  readonly subtitle: string
+  readonly description: string
+  readonly cards: readonly AchievementTemplateCard[]
+  readonly note: string
+} = {
+  title: 'Достижения и результаты',
+  subtitle: 'Шаблонный блок',
+  description:
+    'Используйте этот блок как шаблон: замените примеры ниже на реальные кейсы, сертификаты и измеримые результаты.',
+  cards: [
+    {
+      id: 'education-template',
+      icon: 'certificate',
+      title: 'Профессиональная квалификация',
+      period: 'Пример: 2025',
+      summary: 'Добавьте ключевое обучение, диплом или сертификацию.',
+      bullets: [
+        'Название программы или института',
+        'Формат обучения (очно/онлайн)',
+        'Как это усиливает работу с клиентами',
+      ],
+    },
+    {
+      id: 'case-template',
+      icon: 'case',
+      title: 'Кейс клиента',
+      period: 'Пример: 8 недель работы',
+      summary: 'Опишите исходный запрос, этапы работы и динамику по неделям.',
+      bullets: [
+        'Запрос клиента в 1-2 предложениях',
+        'Что было внедрено (питание, режим, поддержка)',
+        'Промежуточные точки контроля',
+      ],
+    },
+    {
+      id: 'result-template',
+      icon: 'result',
+      title: 'Измеримый результат',
+      period: 'Пример: до/после',
+      summary: 'Укажите конкретные метрики, которые клиент видит в жизни и анализах.',
+      bullets: [
+        'Показатель 1: было -> стало',
+        'Показатель 2: было -> стало',
+        'Короткий отзыв в 1 фразе',
+      ],
+    },
+  ],
+  note:
+    'Примечание: блок содержит шаблонные формулировки. Замените их перед публикацией на проверенные факты и реальные цифры.',
+}


### PR DESCRIPTION
Closes #1

Что сделано:
- Добавлена секция Achievements (якорь #achievements) с шаблонными карточками.
- Контент вынесен в src/lib/content/achievements.ts.
- Добавлен пункт навигации в Header/Footer и отображение в Breadcrumbs.

Важно:
- Тексты/цифры в шаблоне нужно заменить на реальные перед публикацией.